### PR TITLE
Add a fallback check for the 2.x backup configuration

### DIFF
--- a/etcd-2.3/bin/snap-wrap.sh
+++ b/etcd-2.3/bin/snap-wrap.sh
@@ -13,19 +13,28 @@ else
   echo "Running as system wih data in $DATA_DIR"
 fi
 
+
 # Migrate older config to new location
 if [ -e $DATA_DIR/etcd.conf ]; then
   echo "Moving configuration to $CONF_DIR"
   mv $DATA_DIR/etcd.conf $CONF_DIR/
 fi
 
+
 # See if there is a configuration file
 TARGET_CONF=$CONF_DIR/etcd.conf
+FALLBACK_CONFIG="${TARGET_CONF}.2x"
 if [ -e $TARGET_CONF ]; then
   # The desired configuration file is already in place
   echo "Configuration from $TARGET_CONF"
   set -o allexport
   . $TARGET_CONF
+  set +o allexport
+elif [ -e $FALLBACK_CONFIG ]; then
+  # We've migrated and reverted to a 2.x series state
+  echo "Configuration from fallback ${TARGET_CONF}.2x"
+  set -o allexport
+  . "${TARGET_CONF}.2x"
   set +o allexport
 else
   echo "Please install config at $TARGET_CONF, then restart snap.etcd"


### PR DESCRIPTION
When moving forward etcd runs a configuration transaction and renames
the original 2.x series config to `etcd.conf.2x`. I feel it makes sense
to look for the 2.x configuration and use it as a fallback mechanism
before defaulting to error should the user attempt to `snap revert etcd`

If accepted closes #1 