### PR TITLE
Adds the pluggable media interface for durable storage

### DIFF
--- a/etcd-2.3/snap/snapcraft.yaml
+++ b/etcd-2.3/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
   etcd:
     daemon: simple
     command: snap-wrap.sh
-    plugs: [ network-bind ]
+    plugs: [ network-bind, removable-media ]
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]

--- a/etcd-3.0/snap/snapcraft.yaml
+++ b/etcd-3.0/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
   etcd:
     daemon: simple
     command: snap-wrap.sh
-    plugs: [ network-bind ]
+    plugs: [ network-bind, removable-media ]
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]

--- a/etcd-3.1/snap/snapcraft.yaml
+++ b/etcd-3.1/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
   etcd:
     daemon: simple
     command: snap-wrap.sh
-    plugs: [ network-bind ]
+    plugs: [ network-bind, removable-media ]
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]


### PR DESCRIPTION
Adding the pluggable media interface will give the snap the capability
of accessing volumes in /media, where we can mount durable data storage