### PR TITLE
Adding the etcdctl aliases for 2.3 and 3.0 channels.

### DIFF
--- a/etcd-2.3/snap/snapcraft.yaml
+++ b/etcd-2.3/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]
+    aliases:
+      - etcdctl
 
 parts:
   etcd:

--- a/etcd-3.0/TODO
+++ b/etcd-3.0/TODO
@@ -1,3 +1,2 @@
 
  * comprehensive migration of all etcd options from 2.x to 3.x
- * alias for etcdctl

--- a/etcd-3.0/snap/snapcraft.yaml
+++ b/etcd-3.0/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]
+    aliases:
+      - etcdctl
 
 parts:
   etcd:


### PR DESCRIPTION
We got a request for the etcdctl alias in the 2.3 etcd snap channel.

https://github.com/juju-solutions/layer-etcd/issues/92